### PR TITLE
Fixed error in functions ex 4, how odd

### DIFF
--- a/05-Bash-Programming.Rmd
+++ b/05-Bash-Programming.Rmd
@@ -1777,7 +1777,7 @@ howodd 42 6 7 9 33
 ```
 
 ```
-## .40
+## .60
 ```
 
 ```{r, engine='bash', eval=FALSE}

--- a/guestbook.md
+++ b/guestbook.md
@@ -160,3 +160,4 @@
 - Alexandre Cadima
 - Palatip Jopanya John
 - Rebecca B
+- Kalki Sharma


### PR DESCRIPTION
howodd 42 6 7 9 33

howodd prints the percentage of odd numbers in a sequence of numbers

There are 3 odd numbers in this sequence of 5 numbers. result should be 0.60 (rather than 0.40, which is the proportion of even numbers).