### PR TITLE
Rephrased reference to regular expressions

### DIFF
--- a/06-Git-and-GitHub.Rmd
+++ b/06-Git-and-GitHub.Rmd
@@ -545,11 +545,11 @@ And as you can see the changes we made to `readme.txt` have been undone.
 Sometimes you might have files that you never want Git to track, for example
 binary files that are generated as by-products of running code (PDFs or images),
 or secrets like passwords or API keys. A file in your Git repository called
-`.gitignore` can list names of files and sub-folders, or simple regular
-expressions (whatever you can use with `ls`) in order to specify files which
-should never be tracked. Each line of a `.gitignore` file should specify a file
-or group of files that should not be tracked by Git. Let's make a `.gitignore`
-file to make sure that we never track image files in this repository:
+`.gitignore` can list names of files and sub-folders, or simple patterns that use 
+wild cards in order to specify files which should never be tracked. Each line of 
+a `.gitignore` file should specify a file or group of files that should not be 
+tracked by Git. Let's make a `.gitignore` file to make sure that we never track 
+image files in this repository:
 
 ```{r, engine='bash', eval=FALSE}
 touch toby.jpg


### PR DESCRIPTION
This section of your text refers to pattern matching in .gitignore, which doesn't match patterns as POSIX regular expressions, but rather uses [its own pattern matching rules](https://git-scm.com/docs/gitignore). These rules include treating the pattern as a shell glob (using the metacharacters `*`, `?` and `[` to match file names in the command line). 

You don't go into globbing in much detail, but do cover the use of `*` in the section titled "Get Wild" (under "Working with Unix"). The reference to regular expressions here is confusing. It may be better to describe it using the language from that section ("Get Wild"): "patterns that use wild cards", rather than to say "regular expressions", and then qualify that as "anything that you can use with `ls`".  The suggested change in phrasing should remind readers of that subsection, which is helpful, since the `*` shell glob metacharacter is exactly what you describe in that subsection.