### PR TITLE
Mismatch of the input and result in example

### DIFF
--- a/06-Git-and-GitHub.Rmd
+++ b/06-Git-and-GitHub.Rmd
@@ -459,7 +459,7 @@ Git can also help show the differences between unstaged changes to your files
 compared to the last commit. Let's add a new line of text to `readme.txt`:
 
 ```{r, engine='bash', eval=FALSE}
-echo "The third line." >> readme.txt
+echo "I added a line." >> readme.txt
 git diff readme.txt
 ```
 


### PR DESCRIPTION
The third line added into readme.txt is added by command "echo "The third line." >> readme.txt", but there and after into the exercise the third line is shown as "I added a line".