### PR TITLE
zsh is default on MacOS

### DIFF
--- a/01-What-is-Unix.Rmd
+++ b/01-What-is-Unix.Rmd
@@ -18,4 +18,4 @@ havoc on yourself and on others. Like
 said: "With great power comes great responsibility."
 
 There are several popular shell programs but in this book we'll be using a shell 
-called Bash because it is the default shell program on Mac and Ubuntu.
+called Bash because it is a common shell program on Mac and Ubuntu.


### PR DESCRIPTION
Starting with Catalina, zsh, not bash, is default. 

Relevant Apple support page: https://support.apple.com/en-us/HT208050